### PR TITLE
add link to edit the tutorial pages on github.

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -190,6 +190,14 @@ private fun HTML.generateDocumentationPage(docFile: MdFileDescriptor) {
                     div {
                         classes += "site-text"
                         unsafe {
+                            //language=HTML
+                            + """
+                            <a href="https://github.com/data2viz/play.data2viz.io/edit/master/content/tutorials/${docFile.name}" class="page-link-to-github" target="_blank" title="Edit this page on GitHub">
+                                <i class="github-icon"></i>
+                                <span class="text">Edit Page</span>
+                            </a>
+                            """.trimIndent()
+
                             +docFile.htmlContent
                         }
                     }


### PR DESCRIPTION
This idea is to give a link to simplify the current page edition.

Please @azertypow add the necessary css so it look like [kotlin documentation page](https://kotlinlang.org/docs/reference/classes.html).